### PR TITLE
Add spellcasting usage die mechanic

### DIFF
--- a/pages/classes/wise.md
+++ b/pages/classes/wise.md
@@ -4,9 +4,13 @@
 
 **Starting Equipment:** Quarterstaff (1d6)
 
-| Level | Proficiency | Class Features  |
-| ----  | ----------- |- |
-| 1st   | +2          | Archetype, Proficient: Insight, Proficient: [Cunning](pages/characters/attributes.md?id=cunning) [saves](pages/rules/rolling.md?id=saves), Proficient: All weapons, shields and armour |
+| Level | Proficiency | Wise | Class Features  |
+| ----  | ----------- |----- | - |
+| 1st   | +2          | d4   | Archetype, Proficient: Insight, Proficient: [Cunning](pages/characters/attributes.md?id=cunning) [saves](pages/rules/rolling.md?id=saves), Proficient: All weapons, shields and armour |
+
+### Wise
+
+**Wise** is a [usage die](rules/usage-die.md) that represents the resources you draw upon to use your class features. These could be intellectual will, arcane might or divine favour.
 
 ### Archetype
 
@@ -26,7 +30,7 @@ You can touch one willing creature. For 1 minute the target can roll a d4 and ad
 
 ### Miracles
 
-You can perform one of the miracles below once per rest. Each miracle takes an action to perform.
+You can perform the miracles below. Each miracle takes an action to perform. Roll your **Wise**.
 
 #### Miracle: Halo
 


### PR DESCRIPTION
Mechanic to make spellcasting more dynamic. Add a **Wise** [usage die](https://github.com/grislyeye/three-meet/pull/5) that you roll to cast. If you exhaust it you cannot cast spells any more.

~Possibly negative side effect if you do exhaust?~ No, this will mean players will be punished for using their class features.