### PR TITLE
Fix: uninspired "Street Wise" speciality feature

### DIFF
--- a/license.md
+++ b/license.md
@@ -35,4 +35,6 @@ as Open Game Content by the Contributor, and means any work covered by this Lice
 
 * Open Game License v 1.0 Copyright 2000, Wizards of the Coast, Inc.
 * System Reference Document 5.1 Copyright 2016, Wizards of the Coast, Inc.; Authors Mike Mearls, Jeremy Crawford, Chris Perkins, Rodney Thompson, Peter Lee, James Wyatt, Robert J. Schwalb, Bruce R. Cordell, Chris Sims, and Steve Townshend, based on original material by E. Gary Gygax and Dave Arneson.
+* Swords & Wizardry Core Rules, Copyright 2008 Matthew J. Finch. 13th Age, Copyright 2013 Fire Opal Media.
+* Low Fantasy Gaming (Original), Copyright Pickpocket Press 2016.
 * Three Meet 0.2.0 Copyright 2020-2021, R.G Wood

--- a/pages/backgrounds/knave.md
+++ b/pages/backgrounds/knave.md
@@ -62,8 +62,8 @@ You grew up running the city streets, playing games, stealing food, dodging the 
 
 | Level             | Speciality Features    |
 | ----------------- | - |
-| 1st               | Proficient: Deception, Street Wise |
+| 1st               | Proficient: Deception, Slippery |
 
-### Street Wise
+### Slippery
 
-You can add double your proficiency bonus to any [Wisdom](pages/characters/attributes/wisdom.md) [check](pages/rules/rolling?id=checks) related to cities.
+You have advantage on checks to escape bonds such as manacles, or nets. Additionally, you have advantage on checks to evade being followed or tracked.


### PR DESCRIPTION
Switched to new Ragamuffin speciality feature based on Slippery Bastard
unique feature from Low Fantasy Gaming.