### PR TITLE
Ruffian background

### DIFF
--- a/pages/backgrounds/knave.md
+++ b/pages/backgrounds/knave.md
@@ -72,8 +72,8 @@ You can add double your proficiency bonus to any [Wisdom](pages/characters/attri
 
 | Level             | Speciality Features    |
 | ----------------- | - |
-| 1st               | Proficient: Intimidation, Strong Arm |
+| 1st               | Proficient: Intimidation, Tough |
 
-### Strong Arm
+### Tough
 
-Once per rest you can put on an intimidating demeanour. For the next 10 minutes you have Advantage on Intimidation checks, but Disadvantage on Persuasion checks. Additionally, you have Advantage on Saves to resist Intimidation checks or the Frightening condition.
+You can use [Intimidation](pages/characters/skills#intimidation), when you would normally roll for [Insight](pages/characters/skills#insight) or [Deception](pages/characters/skills#deception).

--- a/pages/backgrounds/knave.md
+++ b/pages/backgrounds/knave.md
@@ -78,4 +78,4 @@ You're basically a thug, running enforcement, protection rackets, or acting as b
 
 ### Tough
 
-You can make an [Intimidation](pages/characters/skills#intimidation) [Check](pages/rules/rolling#checks), when you would normally make a [Check](pages/rules/rolling#checks) for [Insight](pages/characters/skills#insight) or [Deception](pages/characters/skills#deception).
+You're tough as old boots. While you are not wearing any armour, your [Defence](pages/combat/attacks?id=defence) equals **10 + [Cunning](pages/characters/attributes?id=cunning) + [Might](pages/characters/attributes?id=might)**.

--- a/pages/backgrounds/knave.md
+++ b/pages/backgrounds/knave.md
@@ -72,6 +72,8 @@ You can add double your proficiency bonus to any [Wisdom](pages/characters/attri
 
 | Level             | Speciality Features    |
 | ----------------- | - |
-| 1st               | Proficient: Intimidation, Tough |
+| 1st               | Proficient: Intimidation, Strong Arm |
 
-### Tough
+### Strong Arm
+
+Once per rest you can put on an intimidating demeanour. For the next 10 minutes you have Advantage on Intimidation checks, but Disadvantage on Persuasion checks. Additionally, you have Advantage on Saves to resist Intimidation checks or the Frightening condition.

--- a/pages/backgrounds/knave.md
+++ b/pages/backgrounds/knave.md
@@ -78,4 +78,4 @@ You're basically a thug, running enforcement, protection rackets, or acting as b
 
 ### Tough
 
-You can use [Intimidation](pages/characters/skills#intimidation), when you would normally roll for [Insight](pages/characters/skills#insight) or [Deception](pages/characters/skills#deception).
+You can make an [Intimidation](pages/characters/skills#intimidation) [Check](pages/rules/rolling#checks), when you would normally make a [Check](pages/rules/rolling#checks) for [Insight](pages/characters/skills#insight) or [Deception](pages/characters/skills#deception).

--- a/pages/backgrounds/knave.md
+++ b/pages/backgrounds/knave.md
@@ -70,7 +70,7 @@ You have advantage on checks to escape bonds such as manacles, or nets. Addition
 
 ## Ruffian
 
-You're basically a thug, running enforcement, protection rackets, or acting as bodyguards to your criminal masters.
+You're basically a thug, running enforcement, protection rackets, or acting as bodyguard to your criminal masters.
 
 | Level             | Speciality Features    |
 | ----------------- | - |

--- a/pages/backgrounds/knave.md
+++ b/pages/backgrounds/knave.md
@@ -70,6 +70,8 @@ You have advantage on checks to escape bonds such as manacles, or nets. Addition
 
 ## Ruffian
 
+You're basically a thug, running enforcement, protection rackets, or acting as bodyguards to your criminal masters.
+
 | Level             | Speciality Features    |
 | ----------------- | - |
 | 1st               | Proficient: Intimidation, Tough |

--- a/pages/backgrounds/knave.md
+++ b/pages/backgrounds/knave.md
@@ -30,7 +30,7 @@ You know thieves’ cant, a secret code of dialect, hand-signs, jargon, ciphers,
 
 </header>
 
-You specialised in a particular criminal enterprise. Choose a speciality and gain its features. Knave specialities include:  **Burglar** and **Ragamuffin**.
+You specialised in a particular criminal enterprise. Choose a speciality and gain its features. Knave specialities include:  **Burglar**, **Ragamuffin**, and [Ruffian](#ruffian).
 
 <header>
 
@@ -67,3 +67,11 @@ You grew up running the city streets, playing games, stealing food, dodging the 
 ### Street Wise
 
 You can add double your proficiency bonus to any [Wisdom](pages/characters/attributes/wisdom.md) [check](pages/rules/rolling?id=checks) related to cities.
+
+## Ruffian
+
+| Level             | Speciality Features    |
+| ----------------- | - |
+| 1st               | Proficient: Intimidation, Tough |
+
+### Tough


### PR DESCRIPTION
Based on the following feedback for the Ragamuffin background:

> Mechanically I can use either with Red, though flavor wise they’re a lil more on the agile/cunning/slippery side of the ‘urchin’/knave archetype. So just in case you’d like the feedback, there could maybe be a background feature that leans more to the ‘biggest kid on the playground’/bouncer/muscles type of archetype? 
