### PR TITLE
[wip] Add: Ragamuffin speciality

### DIFF
--- a/pages/backgrounds/knave.md
+++ b/pages/backgrounds/knave.md
@@ -30,7 +30,7 @@ You know thieves’ cant, a secret code of dialect, hand-signs, jargon, ciphers,
 
 </header>
 
-You specialised in a particular criminal enterprise. Choose a speciality and gain its features. Knave specialities include:  **Burglar** and [Ruffian](#ruffian).
+You specialised in a particular criminal enterprise. Choose a speciality and gain its features. Knave specialities include:  **Burglar**, **Ragamuffin**, and [Ruffian](#ruffian).
 
 <header>
 
@@ -55,6 +55,18 @@ You specialised in a particular criminal enterprise. Choose a speciality and gai
 </header>
 
 You gain the ability to climb twice as fast. When you make a running jump double the distance you can cover.
+
+## Ragamuffin
+
+You grew up running the city streets, playing games, stealing food, dodging the watch, scrapping and generally running amok. You survived, despite the odds, through your wits and by making yourself useful to the local criminal elements.
+
+| Level             | Speciality Features    |
+| ----------------- | - |
+| 1st               | Proficient: Deception, Slippery |
+
+### Slippery
+
+You have advantage on checks to escape bonds such as manacles, or nets. Additionally, you have advantage on checks to evade being followed or tracked.
 
 ## Ruffian
 


### PR DESCRIPTION
Ragamuffin speciality removed from `main`. Slippery feature too weak.

My current thinking on background feature design:

Bad background/speciality features:

 * Are achievable with an existing skill (e.g. mimicry)
 * Replicate Expertise Cunning class feature
 * Just give situational advantage (advantage is situational anyway)
 * Have combat utility

Good background/speciality features:

 * Allow you to substitute one proficiency for another (effectively doubling the proficiency's utility)
 * Make an exception to the rules