### PR TITLE
Fix: Terminology does not reflect abstract damage

### DIFF
--- a/_sidebar.md
+++ b/_sidebar.md
@@ -28,7 +28,7 @@
   + [Moves](pages/combat/moves.md)
   + [Bonus Actions](pages/combat/bonus-actions.md)
   + [Reactions](pages/combat/reactions.md)
-  + [Health](pages/combat/health.md)
+  + [Stamina](pages/combat/stamina.md)
 + Colophon
   + [Design Notes](design-notes.md)
   + [Contributing](contributing.md)

--- a/design-notes.md
+++ b/design-notes.md
@@ -26,7 +26,7 @@ Magical creatures are extremely rare, and many mechanics from spells and monster
 
 ### Meaningful Terms
 
-5E comes with a lot of obscure terminology, like HP, saving throws and AC. Three Meet uses natural language terms, such as [Health](pages/combat/health.md) or [Saves](pages/rules/rolling/saves.md).
+5E comes with a lot of obscure terminology, like HP, saving throws and AC. Three Meet uses natural language terms, such as [Stamina](pages/combat/stamina.md) or [Saves](pages/rules/rolling/saves.md).
 
 </section>
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-meet",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "A low-fantasy 5E hack for dark times",
   "author": "R.G. Wood <ric@grislyeye.com> (https://grislyeye.com)",
   "homepage": "https://github.com/grislyeye/three-meet#readme",

--- a/pages/characters/attributes.md
+++ b/pages/characters/attributes.md
@@ -23,7 +23,7 @@ All creatures are described by three **Attributes** representing their physical 
 
 Raw strength, stamina, and combat prowess.
 
-Added to [Health](pages/combat/health.md), and melee [Attacks](pages/combat/attacks.md) and [Damage](pages/combat/attacks.md) rolls.
+Added to [Stamina](pages/combat/stamina.md), and melee [Attacks](pages/combat/attacks.md) and [Damage](pages/combat/attacks.md) rolls.
 
 </section>
 

--- a/pages/classes/cunning.md
+++ b/pages/classes/cunning.md
@@ -12,7 +12,7 @@
 
 ### Starting Stats
 
-**Starting Health:** 8 + [Might](pages/characters/attributes.md?id=might)
+**Starting [Stamina](pages/combat/stamina.md):** 8 + [Might](pages/characters/attributes.md?id=might)
 
 **Proficiencies:** Any 1 skill, [Cunning](pages/characters/attributes.md?id=cunning) [Saves](pages/rules/rolling/saves.md)
 

--- a/pages/classes/mighty.md
+++ b/pages/classes/mighty.md
@@ -12,7 +12,7 @@
 
 ### Starting Stats
 
-**Starting Health:** 10 + [Might](pages/characters/attributes.md?id=might)
+**Starting [Stamina](pages/combat/stamina.md):** 10 + [Might](pages/characters/attributes.md?id=might)
 
 **Proficiencies:** Athletics, [Might](pages/characters/attributes.md?id=might) [Saves](pages/rules/rolling/saves.md), all armor, shields, simple weapons, and martial weapons
 
@@ -32,7 +32,7 @@ When you use your Surge, you choose which feat to use. You must then finish a re
 
 #### Surge: Second Wind
 
-As a [Bonus Action](pages/combat/bonus-actions.md) you can regain [Health](pages/combat/health.md) equal to **1d10 + your level**.
+As a [Bonus Action](pages/combat/bonus-actions.md) you can regain [Stamina](pages/combat/stamina.md) equal to **1d10 + your level**.
 
 <header>
 

--- a/pages/classes/wise.md
+++ b/pages/classes/wise.md
@@ -12,7 +12,7 @@
 
 ### Starting Stats
 
-**Starting Health:** 8 + [Might](pages/characters/attributes.md?id=might)
+**Starting [Stamina](pages/combat/stamina.md):** 8 + [Might](pages/characters/attributes.md?id=might)
 
 **Proficiencies:** Insight, [Wisdom](pages/characters/attributes.md?id=wisdom) [Saves](pages/rules/rolling/saves.md)
 
@@ -104,7 +104,7 @@ You make yourself, including your clothing, armour, weapons, and other belonging
 
 </header>
 
-You summon a **Minor Spirit (1 Health, 10 Defence, Stealth +4)**. It always obeys your commands and can be used to move small objects, and stealthily observe and report back to you. It vanishes after 10 minutes or when you dismiss it.
+You summon a **Minor Spirit (1 [Stamina](pages/combat/stamina.md), 10 Defence, Stealth +4)**. It always obeys your commands and can be used to move small objects, and stealthily observe and report back to you. It vanishes after 10 minutes or when you dismiss it.
 
 </section>
 

--- a/pages/combat/attacks.md
+++ b/pages/combat/attacks.md
@@ -12,7 +12,7 @@ You can make one attack per turn. When you make an attack:
  2. Make a [Check](pages/rules/rolling/checks.md)
  3. Add your [Proficiency](pages/rules/proficiency.md) if you are proficient with the attack
  4. The difficulty is the opponent's **Defence**
- 5. If you hit, roll for damage
+ 5. If you hit, roll for damage and take that from the target's [Stamina](pages/combat/stamina)
 
 ### Describing Attacks
 

--- a/pages/combat/health.md
+++ b/pages/combat/health.md
@@ -1,6 +1,0 @@
-# Health
-
-**Health** represent a combination of physical and mental durability, the will to live, and luck:
-
- + When a creature takes damage it is is subtracted from its Health.
- + When a creature drops to 0 Health it dies

--- a/pages/combat/stamina.md
+++ b/pages/combat/stamina.md
@@ -10,6 +10,6 @@
 
 ### Damage
 
-**Stamina** damage is abstract. It doesn't just represent physical harm. It can represent mental stress, off-balance, misfortune, shock,
+**Stamina** damage is abstract. It doesn't just represent physical harm. It can represent mental stress, off-balance, misfortune, or shock.
 
 A successful [Attack](pages/combat/attacks.md) might translate to a near miss that knocks you off-balance, a palpating fear you're outmatched, a light scratch, or temporary concussion. And, of course, a direct hit.

--- a/pages/combat/stamina.md
+++ b/pages/combat/stamina.md
@@ -4,3 +4,9 @@
 
  + When a creature takes damage, it is subtracted from its **Stamina**.
  + When a creature drops to 0 **Stamina** it dies.
+
+### Damage
+
+**Stamina** damage is abstract. It doesn't just represent physical harm. It can represent mental stress, off-balance, misfortune, shock,
+
+A successful [Attack](pages/combat/attacks.md) might translate to a near miss that knocks you off-balance, a palpating fear you're outmatched, a light scratch, or temporary concussion. And, of course, a direct hit.

--- a/pages/combat/stamina.md
+++ b/pages/combat/stamina.md
@@ -1,3 +1,6 @@
+<!--
+  Stamina replaces the abstruse term HP. It also encapsulates the idea that damage is abstract.
+-->
 # Stamina
 
 **Stamina** represent a combination of physical and mental durability, grit, willpower, and just plain luck:

--- a/pages/combat/stamina.md
+++ b/pages/combat/stamina.md
@@ -12,4 +12,4 @@
 
 **Stamina** damage is abstract. It doesn't just represent physical harm. It can represent mental stress, off-balance, misfortune, or shock.
 
-A successful [Attack](pages/combat/attacks.md) might translate to a near miss that knocks you off-balance, a palpating fear you're outmatched, a light scratch, or temporary concussion. And, of course, a direct hit.
+A successful [Attack](pages/combat/attacks.md) might translate to a near miss that knocks you off-balance, a palpating fear you're outmatched, a light scratch, or temporary concussion. Or, of course, a direct hit.

--- a/pages/combat/stamina.md
+++ b/pages/combat/stamina.md
@@ -1,0 +1,6 @@
+# Stamina
+
+**Stamina** represent a combination of physical and mental durability, grit, willpower, and just plain luck:
+
+ + When a creature takes damage, it is subtracted from its **Stamina**.
+ + When a creature drops to 0 **Stamina** it dies.

--- a/pages/rules/rests.md
+++ b/pages/rules/rests.md
@@ -12,5 +12,5 @@ A rest is a 8 hours of extended downtime during which a character sleeps or perf
 
 A rest confers the following benefits:
 
-  * Regain all [Health](pages/combat/health.md)
+  * Regain all [Stamina](pages/combat/stamina.md)
   * Regain expended [Class](pages/classes/index) and [Background](pages/backgrounds/index) features


### PR DESCRIPTION
Health terminology does not reflect the abstract nature of damage. This
alters the terminology to be more coherent with this design goal.

In this case, we picked the term "Stamina", which reflects physical and
mental durability.