### PR TITLE
Fix: Defender Block surge is underpowered

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "three-meet",
-  "version": "0.8.1",
+  "version": "0.10.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "three-meet",
-      "version": "0.8.1",
+      "version": "0.10.0",
       "license": "OGL",
       "dependencies": {
         "docsify": ">=4.12.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-meet",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "A low-fantasy 5E hack for dark times",
   "author": "R.G. Wood <ric@grislyeye.com> (https://grislyeye.com)",
   "homepage": "https://github.com/grislyeye/three-meet#readme",

--- a/pages/classes/mighty.md
+++ b/pages/classes/mighty.md
@@ -76,4 +76,4 @@ You can use your [Reaction](pages/combat/reactions.md) to impose disadvantage on
 
 </header>
 
-You can use your [Bonus Action](pages/combat/bonus-actions.md) to position yourself defensively around a [Close](pages/rules/distance) ally. The ally gains **1d10 + your level** [Temporary Stamina](pages/combat/stamina#temporary-stamina).
+You can use your [Bonus Action](pages/combat/bonus-actions.md) to direct a [Close](pages/rules/distance) ally defensively. The ally gains **1d10 + your level** [Temporary Stamina](pages/combat/stamina#temporary-stamina). This Temporary Stamina is lost after combat finishes.

--- a/pages/classes/mighty.md
+++ b/pages/classes/mighty.md
@@ -54,11 +54,11 @@ You fight to protect. Cleaving close to your allies, you intercept attacks so th
 
 | Level | Archetype Features |
 | ----  | ------------------ |
-| 1st   | Defend, Surge: Block, Proficient: Intimidation         |
+| 1st   | Block, Surge: Defend, Proficient: Intimidation |
 
 <header>
 
-### Defend
+### Block
 
 <p class="subheading">1st-level Defender archetype feature</p>
 
@@ -68,10 +68,11 @@ You can use your [Reaction](pages/combat/reactions.md) to impose disadvantage on
 
 <header>
 
-### Surge: Block
+### Surge: Defend
 
 <p class="subheading">1st-level Defender archetype feature</p>
 
 </header>
 
-You can use your [Reaction](pages/combat/reactions.md) to reduce the damage from an [Attack](pages/combat/attacks.md) that targets an ally by **1d10 + your Level**. The target must be within 5 feet of you, and you must be wielding a melee weapon or shield.
+You can use your [Bonus Action](pages/combat/bonus-actions.md) to give a [Close](pages/rules/distance) ally **1d10 + your level** [Temporary Stamina]().
+

--- a/pages/classes/mighty.md
+++ b/pages/classes/mighty.md
@@ -74,5 +74,4 @@ You can use your [Reaction](pages/combat/reactions.md) to impose disadvantage on
 
 </header>
 
-You can use your [Bonus Action](pages/combat/bonus-actions.md) to give a [Close](pages/rules/distance) ally **1d10 + your level** [Temporary Stamina]().
-
+You can use your [Bonus Action](pages/combat/bonus-actions.md) to position yourself defensively around a [Close](pages/rules/distance) ally. The ally gains **1d10 + your level** [Temporary Stamina]().

--- a/pages/classes/mighty.md
+++ b/pages/classes/mighty.md
@@ -76,4 +76,4 @@ You can use your [Reaction](pages/combat/reactions.md) to impose disadvantage on
 
 </header>
 
-You can use your [Bonus Action](pages/combat/bonus-actions.md) to position yourself defensively around a [Close](pages/rules/distance) ally. The ally gains **1d10 + your level** [Temporary Stamina]().
+You can use your [Bonus Action](pages/combat/bonus-actions.md) to position yourself defensively around a [Close](pages/rules/distance) ally. The ally gains **1d10 + your level** [Temporary Stamina](pages/combat/stamina#temporary-stamina).

--- a/pages/combat/stamina.md
+++ b/pages/combat/stamina.md
@@ -13,3 +13,14 @@
 **Stamina** damage is abstract. It doesn't just represent physical harm. It can represent mental stress, off-balance, misfortune, or shock.
 
 A successful [Attack](pages/combat/attacks.md) might translate to a near miss that knocks you off-balance, a palpating fear you're outmatched, a light scratch, or temporary concussion. Or, of course, a direct hit.
+
+### Temporary Stamina
+
+Some spells and special abilities confer **Temporary Stamina**. When you have Temporary Stamina and take damage, the Temporary Stamina is lost first, and any leftover damage carries over to your normal Stamina.
+
+**Temporary Stamina**:
+
+  * Can exceed your Stamina maximum.
+  * Cannot be restored.
+  * Does not stack: if you receive more Temporary Stamina, you decide whether to keep the ones you have or to gain the new ones.
+  * They last until they're depleted, or you finish a long rest.


### PR DESCRIPTION
The Defender Block surge uses a reaction, which nerfs the Defend class feature by reducing the number of times you can use it in combat.

This change fixes this by making the surge a bonus action, eliminating competition for reactions.