### PR TITLE
Fix: buff under-powered Swashbuckler feature

### DIFF
--- a/pages/classes/cunning.md
+++ b/pages/classes/cunning.md
@@ -99,7 +99,7 @@ With wit, flair, and fancy footwork you leap head first into combat, running rin
 
 | Level | Features
 | ----  | -
-| 1st   | Swashbuckle
+| 1st   | Daring Attack
 
 ### Starting Stats
 
@@ -107,7 +107,7 @@ With wit, flair, and fancy footwork you leap head first into combat, running rin
 
 <header>
 
-### Swashbuckle
+### Daring Attack
 
 <p class="subheading">1st-level Swashbuckler archetypes feature</p>
 

--- a/pages/classes/cunning.md
+++ b/pages/classes/cunning.md
@@ -113,4 +113,4 @@ With wit, flair, and fancy footwork you leap head first into combat, running rin
 
 </header>
 
-You do not need advantage to use your [Cunning Attack](#cunning-attack) against a creature when you are **Close** to it, and no other creatures are **Close** to you.
+You do not need advantage to use your [Cunning Attack](#cunning-attack) against a **Close** creature if there are no other creatures **Close** to you. You also do not need advantage if a creature has not yet moved on its [Turn](../../pages/combat/order.md).

--- a/pages/classes/cunning.md
+++ b/pages/classes/cunning.md
@@ -113,4 +113,4 @@ With wit, flair, and fancy footwork you leap head first into combat, running rin
 
 </header>
 
-You do not need advantage to use your [Cunning Attack](#cunning-attack) against a **Close** creature if there are no other creatures **Close** to you. You also do not need advantage if a creature has not yet moved on its [Turn](../../pages/combat/order.md).
+You do not need advantage to use your [Cunning Attack](#cunning-attack) against a **Close** creature if there are no other creatures **Close** to you. You also do not need advantage against a **Close** creature if you've already moved on your [Turn](../../pages/combat/order.md).

--- a/pages/classes/cunning.md
+++ b/pages/classes/cunning.md
@@ -113,4 +113,4 @@ With wit, flair, and fancy footwork you leap head first into combat, running rin
 
 </header>
 
-You do not need advantage to use your [Cunning Attack](#cunning-attack) against a **Close** creature if there are no other creatures **Close** to you. You also do not need advantage against a **Close** creature if you've already moved during the current [Round](../../pages/combat/order.md).
+You do not need advantage to use your [Cunning Attack](#cunning-attack) against a **Close** creature if there are no other creatures **Close** to you. You also do not need advantage against a creature if it isn't wielding a [Light](../../pages/combat/attacks.md) weapon.

--- a/pages/classes/cunning.md
+++ b/pages/classes/cunning.md
@@ -113,4 +113,4 @@ With wit, flair, and fancy footwork you leap head first into combat, running rin
 
 </header>
 
-You do not need advantage to use your [Cunning Attack](#cunning-attack) against a **Close** creature if there are no other creatures **Close** to you. You also do not need advantage against a **Close** creature if you've already moved on your [Turn](../../pages/combat/order.md).
+You do not need advantage to use your [Cunning Attack](#cunning-attack) against a **Close** creature if there are no other creatures **Close** to you. You also do not need advantage against a **Close** creature if you've already moved during the current [Round](../../pages/combat/order.md).

--- a/pages/classes/cunning.md
+++ b/pages/classes/cunning.md
@@ -113,4 +113,4 @@ With wit, flair, and fancy footwork you leap head first into combat, running rin
 
 </header>
 
-You do not need advantage to use your [Cunning Attack](#cunning-attack) against a **Close** creature if there are no other creatures **Close** to you. You also do not need advantage against a creature if it isn't wielding a [Light](../../pages/combat/attacks.md) weapon.
+You do not need advantage to use your [Cunning Attack](#cunning-attack) against a **Close** creature if there are no other creatures **Close** to you. You also do not need advantage against a creature that isn't wielding a [Light](../../pages/combat/attacks.md) weapon and doesn't have an [Off-Hand Attack](../../pages/combat/bonus-actions.md#off-hand-attack).


### PR DESCRIPTION
The Swashbuckle class feature is underpowered compared to the 5E rogue Sneak Attack.

Sneak Attack gives the following conditions for extra damage:

 * Advantage
 * Melee
 * Ranged
 * Flanked
 
Swashbuckle only gives:
 
 * Advantage
 * Melee
 * Close

Without an additional condition comparable to using Cunning Attack on a ranged attack, it's underpowered compared to Sneak Attack.