### PR TITLE
Fix: character Stamina is unclear

### DIFF
--- a/pages/classes/cunning.md
+++ b/pages/classes/cunning.md
@@ -6,19 +6,22 @@
 
 </header>
 
-| Level | Proficiency | Features  |
-| ----  | ----------- |- |
-| 1st   | +2          | +1 [Cunning](pages/characters/attributes.md?id=cunning), Archetype, Expertise, Cunning Attack |
+
+| Level | Prof. | Features  |
+| ----  | ----------- | - |
+| 1st   | +2          | +1 [Cunning](pages/characters/attributes.md?id=cunning) <br> Proficient: Cunning Saves <br> Proficient: Any 1 skill <br> Equipment <br> Archetype <br> Cunning <br> Attack Expertise |
 | 2nd   | +2          | Cunning Action |
 | 3rd   | +2          | Archetype Feature |
 
-### Starting Stats
+<header>
 
-**Starting [Stamina](pages/combat/stamina.md):** 8 + [Might](pages/characters/attributes.md?id=might)
+### Equipment
 
-**Proficiencies:** Any 1 skill, [Cunning](pages/characters/attributes.md?id=cunning) [Saves](pages/rules/rolling/saves.md)
+<p class="subheading">1st-level Cunning class feature</p>
 
-**Starting Equipment:** Leather Armour (Defence 11), 2 Daggers (Melee 1d4, Thrown 1d4, Light), and a Crossbow (Ranged 1d8)
+</header>
+
+Leather Armour (Defence 11), 2 Daggers (Melee 1d4, Thrown 1d4, Light), and a Crossbow (Ranged 1d8)
 
 <header>
 

--- a/pages/classes/cunning.md
+++ b/pages/classes/cunning.md
@@ -6,19 +6,11 @@
 
 </header>
 
-| Level | Prof. | Features  |
-| ----  | ----------- | - |
-| 1st   | +2          | +1 [Cunning](pages/characters/attributes.md?id=cunning) <br> Proficient: Cunning Saves <br> Proficient: Any 1 skill <br> Expert Equipment <br>
-| 2nd   | +2          | Cunning Action |
-| 3rd   | +2          | Archetype Feature |
-
-<header>
-
-### Equipment
-
-<p class="subheading">1st-level Cunning class feature</p>
-
-<header>
+| Level | Proficiency | Stamina | Features  |
+| ----  | ----------- | ------- | - |
+| 1st   | +2          | 8       | +1 [Cunning](pages/characters/attributes.md?id=cunning) <br> Proficient: Cunning Saves <br> Proficient: Any 1 skill <br> Expert Equipment <br>
+| 2nd   | +2          | +1d8    | Cunning Action |
+| 3rd   | +2          | +1d8    | Archetype Feature |
 
 ### Expert Equipment
 

--- a/pages/classes/mighty.md
+++ b/pages/classes/mighty.md
@@ -6,10 +6,11 @@
 
 </header>
 
-| Level | Proficiency | Features  |
-| ----  | ----------- |- |
-| 1st   | +2          | +1 [Might](pages/characters/attributes.md?id=might), Martial Gear, Surge, Archetype |
-| 2nd   | +2          | Mighty Action |
+| Level | Proficiency | Stamina | Features  |
+| ----  | ----------- | ------- | - |
+| 1st   | +2          | 10      | +1 [Might](pages/characters/attributes.md?id=might), Martial Gear, Surge, Archetype |
+| 2nd   | +2          | +1d10   | Mighty Action |
+| 2nd   | +2          | +1d10   | Mighty Action |
 
 ### Starting Stats
 

--- a/pages/classes/wise.md
+++ b/pages/classes/wise.md
@@ -6,13 +6,11 @@
 
 </header>
 
-| Level | Proficiency | Class Features  |
-| ----  | ----------- |- |
-| 1st   | +2          | +1 [Wisdom](pages/characters/attributes.md?id=wisdom), Proficient: Insight, Proficient: [Wisdom](pages/characters/attributes.md?id=wisdom) [Saves](pages/rules/rolling/saves.md), Learned Equipment, Archetype |
-
-### Starting Stats
-
-**Starting [Stamina](pages/combat/stamina.md):** 8 + [Might](pages/characters/attributes.md?id=might)
+| Level | Proficiency | Stamina | Features  |
+| ----  | ----------- | ------- | - |
+| 1st   | +2          | 6       | +1 [Wisdom](pages/characters/attributes.md?id=wisdom), Proficient: Insight, Proficient: [Wisdom](pages/characters/attributes.md?id=wisdom) [Saves](pages/rules/rolling/saves.md), Learned Equipment, Archetype |
+| 2nd   | +2          | +1d6    | |
+| 3rd   | +2          | +1d6    | |
 
 <header>
 

--- a/themes/cold-tavern/_table.css
+++ b/themes/cold-tavern/_table.css
@@ -16,6 +16,10 @@
   background-color: black;
 }
 
+.content table td {
+  vertical-align: top;
+}
+
 .content table th.numbers,
 .content table td.numbers {
   text-align: center;

--- a/themes/cold-tavern/_table.css
+++ b/themes/cold-tavern/_table.css
@@ -38,7 +38,16 @@
 
 @media screen and (max-width: 690px) {
   .markdown-section table {
+    table-layout: fixed;
     width: 57.5%;
+  }
+
+  .markdown-section table th {
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    max-width: 40px;
+    max-width: 50px;
   }
 }
 


### PR DESCRIPTION
The starting Stamina for characters was unclear, or missing in some
places. This change makes this clearer and reduces the space by moving
the Stamina to the class tables.