### PR TITLE
Add: lingering affliction rules

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "three-meet",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "three-meet",
-      "version": "0.24.1",
+      "version": "0.25.0",
       "license": "OGL",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^6.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-meet",
-  "version": "0.24.1",
+  "version": "0.25.0",
   "description": "A low-fantasy 5E hack for dark times",
   "author": "R.G. Wood <ric@grislyeye.com> (https://grislyeye.com)",
   "homepage": "https://github.com/grislyeye/three-meet#readme",

--- a/pages/characters/attributes.md
+++ b/pages/characters/attributes.md
@@ -21,7 +21,7 @@ Attribute
 
 Raw strength, stamina, and combat prowess.
 
-Added to [Stamina](../../pages/combat/stamina.md), and melee [Attacks](../../pages/combat/attacks.md) and [Damage](../../pages/combat/attacks.md) rolls.
+Added to [Stamina](../../pages/combat/stamina.md), and melee [Attacks](../../pages/combat/attacks.md) and [Stress](../../pages/combat/attacks.md) rolls.
 
 </section>
 
@@ -33,7 +33,7 @@ Attribute
 
 Wits, speed, agility, dexterousness, charm, perceptiveness, and guile.
 
-Added to [Initiative](../../pages/combat/index.md#initiative), [Defence](../../pages/combat/attacks.md#defence), and ranged [Attacks](../../pages/combat/attacks.md) and [Damage](../../pages/combat/attacks.md) rolls.
+Added to [Initiative](../../pages/combat/index.md#initiative), [Defence](../../pages/combat/attacks.md#defence), and ranged [Attacks](../../pages/combat/attacks.md) and [Stress](../../pages/combat/attacks.md) rolls.
 
 </section>
 

--- a/pages/classes/cunning.md
+++ b/pages/classes/cunning.md
@@ -2,7 +2,7 @@
 
 Class
 
-| Level | Proficiency | Stamina | Cunning Damage | Features  |
+| Level | Proficiency | Stamina | Cunning Stress | Features  |
 | ----  | ----------- | ------- | -------------- | - |
 | 1st   | +2          | 8       | 1d6            | +1 [Cunning](../../pages/characters/attributes.md#cunning) <br> Proficient: Cunning Saves <br> Proficient: Any 1 skill <br> Expert Equipment <br> Cunning Attack <br> Expertise <br> Archetype
 | 2nd   | +2          | +1d8    | 1d6            | Cunning Action |
@@ -23,7 +23,7 @@ You start with the following items:
 
 1st-level Cunning class feature
 
-You can deal extra **Cunning Damage** damage to one creature you hit with an attack, if you have advantage on rolls with a [Light Melee Attack](../../pages/combat/attacks.md#describing-attacks).
+You can deal extra **Cunning Stress** damage to one creature you hit with an attack, if you have advantage on rolls with a [Light Melee Attack](../../pages/combat/attacks.md#describing-attacks).
 
 ## Expertise
 

--- a/pages/classes/mighty.md
+++ b/pages/classes/mighty.md
@@ -71,7 +71,7 @@ When you roll a 1 or 2 on a damage die for an attack you make with a melee weapo
 
 1st-level Berserker archetype feature
 
-On your turn, you can use your surge to enter a rage as a [Bonus Action](../../pages/combat/bonus-actions.md). While raging, you reduce any damage you take by **1d4**.
+On your turn, you can use your surge to enter a rage as a [Bonus Action](../../pages/combat/bonus-actions.md). While raging, you reduce any [Stress](../../pages/combat/stress.md) you take by **1d4**.
 
 Your rage lasts for 1 minute.
 

--- a/pages/classes/wise.md
+++ b/pages/classes/wise.md
@@ -74,7 +74,7 @@ You can sense and purify small amounts of [Close](../../pages/rules/distance.md)
 
 1st-level Elementalist archetype feature
 
-When you are unseen you can use your [Action](../../pages/combat/actions.md) to transform into an **Animal** (Common Creature, **Defence** 10 + Wisdom + Cunning, **Stamina** Wisdom + your level, **Light Melee Attack** 1d6) *or* transform back. If you lose all your **Stamina** in this form you transform back and take any left over damage.
+When you are unseen you can use your [Action](../../pages/combat/actions.md) to transform into an **Animal** (Common Creature, **Defence** 10 + Wisdom + Cunning, **Stamina** Wisdom + your level, **Light Melee Attack** 1d6) *or* transform back. If you lose all your **Stamina** in this form you transform back and take any left over [Stress]().
 
  You can use this feature twice. You regain expended uses when you finish a [Rest](../../pages/rules/rests.md).
 
@@ -128,7 +128,7 @@ When you use your **Animal Form** feature you gain an additional **1d4 + 4 Stami
 
 When you transform you can choose one of the following for your new form:
 
- * You add your **Wisdom** to your attack damage
+ * You add your **Wisdom** to your [Stress]() with [Attacks]()
  * You can see in darkness
  * You become proficient in **Athletics** or **Stealth**
 
@@ -238,7 +238,7 @@ You gain the **[Corrupted](../../pages/rules/conditions.md#corrupted) (Ud8 Resou
 
 2nd-level Sorcerer archetype feature
 
-You can add your [Wisdom](../../pages/characters/attributes.md#wisdom) to the damage of your [Stricken Attack](#stricken).
+You can add your [Wisdom](../../pages/characters/attributes.md#wisdom) to the **Stress** of your [Stricken Attack](#stricken).
 
 <section class="spell">
 
@@ -246,7 +246,7 @@ You can add your [Wisdom](../../pages/characters/attributes.md#wisdom) to the da
 
 2nd-level Sorcerer spell
 
-You summon unseen spirits that whisper three, horrific secrets in the ears of your enemies. Each whisper deals 1d4+1 damage to one or several **Close**, **Nearby** or **Far Away** creatures. When you cast this spell using a 2nd level **Spell Slot** or higher, you can send an additional whisper each slot above 1st.
+You summon unseen spirits that whisper three, horrific secrets in the ears of your enemies. Each whisper deals 1d4+1 [Stress]() to one or several **Close**, **Nearby** or **Far Away** creatures. When you cast this spell using a 2nd level **Spell Slot** or higher, you can send an additional whisper each slot above 1st.
 
 </section>
 

--- a/pages/combat/afflictions.md
+++ b/pages/combat/afflictions.md
@@ -1,0 +1,36 @@
+# Afflictions
+
+Rule
+
+When you are taken [Out of Action](../../pages/combat/stress.md#out-of-action) you acquire can a lingering injury or trauma, called an **Affliction**. Roll a **d20** and refer to the table below:
+
+| d20 | Affliction |
+| --- | -
+| 1-2 | **Death.** You are not alive anymore.
+| 2   | **Deep Wound.** Permanently reduce you [Might]() by 1.
+| 3   | **Head Injury.** Permanently reduce you [Cunning]() by 1.
+| 4   | **Corrupted.** Permanently reduce you [Wisdom]() by 1.
+| 5   | **Withering.** Each time you [Rest]() you must make a **Difficulty 15 Might Check** or you do not regain any [Stamina]().
+| 6   | **Stupor.** You have [Disadvantage]() on all [Cunning]() and [Wisdom]() [Checks]() and [Saves]().
+| 7   | **Pained.** When you take [Stress]() you must make a **Difficulty 15 Might Save** or lose your next [Action]().
+| 8   | **Impaired.** You arm or hand is impaired. You can only use one hand and have [Disadvantage]() on [Might Checks]().
+| 9   | **Slowed.** Your movement is impaired. Your speed is halved and you have [Disadvantage]() on [Cunning Saves]() and **Initiative**.
+| 10  | **Panic.** Until you [Rest]() you have [Advantage]() on all [Cunning]() [Checks](), [Saves]() and [Attacks](). And you have [Disadvantage]() on all [Wisdom]() and [Might]() [Checks](), [Saves]() and [Attacks]()
+| 11  | **Blinded.** Your vision is impaired. You have [Disadvantage]() on [Checks]() related to sight.
+| 12  | **Deafened.** Your hearing is obscured in some way. You have [Disadvantage]() on [Checks]() related to hearing.
+| 13  | **Despair.** You, and anyone who can hear you, have [Disadvantage]() on [Cunning]() [Saves]() and [Attacks](). Each time you [Rest]() you can make a **Difficulty 10 Wisdom Save** to recover from this **Affliction**.
+| 14  | **Frightened.** You, and anyone who can hear you, have [Disadvantage]() on [Wisdom]() [Saves](). Each time you [Rest]() you can make a **Difficulty 10 Wisdom Save** to recover from this **Affliction**.
+| 15  | **Exhausted.** You are [Disadvantaged]() until you [Rest]().
+| 16  | **Mania.** Until you [Rest]() you have [Advantage]() on [Melee Attacks](). And when you make an [Attack](), [Attacks]() against you have [Advantage]() until your next **Turn**.
+| 17  | **Lose Weapon.** You lose a weapon you were wielding.
+| 18  | **Lose Armour.** You lose an item or armour you were wearing.
+| 19  | **Marked.** You gain a permanent mark, such as a scar or involuntary tick.
+| 20  | **Resurgent.** You regain **1d4** [Stress]() and have [Advantage]() on all [Checks](), [Saves]() and [Attacks]() for 1 minute.
+
+If someone successfully tends to you using [Medicine]() you have [Advantage]() when you roll for an **Affliction**.
+
+## Recovery
+
+Rule
+
+How permanent are you Afflictions? [TODO]

--- a/pages/combat/attacks.md
+++ b/pages/combat/attacks.md
@@ -8,7 +8,7 @@ You can make one **Attack** per turn. When you make an **Attack**:
  2. Make a [Check](../../pages/rules/rolling/checks.md)
  3. Add your [Proficiency](../../pages/rules/proficiency.md) if you are proficient with the **Attack**
  4. The difficulty is the opponent's **Defence**
- 5. If you hit, roll for damage and take that from the target's [Stamina](../../pages/combat/stamina.md)
+ 5. If you hit, make a [Stress](../../pages/combat/stamina.md#stress) roll and take that from the target's [Stamina](../../pages/combat/stamina.md)
 
 ## Describing Attacks
 
@@ -18,14 +18,14 @@ Attacks are described by a number of **Tags** listed in parentheses after its na
 
 | Tag       | Description |
 | --------- | - |
-| Finesse     | You can add your [Cunning](../../pages/characters/attributes.md#cunning) instead of [Might](../../pages/characters/attributes.md#might) to melee damage, and attack rolls.
+| Finesse     | You can add your [Cunning](../../pages/characters/attributes.md#cunning) instead of [Might](../../pages/characters/attributes.md#might) to melee [Stress](), and attack rolls.
 | Light     | Can be used for [Off-hand Attacks](../../pages/combat/bonus-actions.md#off-hand-attack).
-| Melee     | Melee attack. Add your [Might](../../pages/characters/attributes.md#might) to the attack roll, and damage.
-| Ranged    | Ranged attack. Add your [Cunning](../../pages/characters/attributes.md#cunning) to the attack roll, and damage.
+| Melee     | Melee attack. Add your [Might](../../pages/characters/attributes.md#might) to the attack roll, and [Stress]().
+| Ranged    | Ranged attack. Add your [Cunning](../../pages/characters/attributes.md#cunning) to the attack roll, and [Stress]().
 | Spell     | Spell attack. Add your [Wisdom](../../pages/characters/attributes.md#wisdom) to the attack roll. Damage is unmodified. You are always [Proficient](../../pages/rules/proficiency.md).
 | Thrown    | You can throw this weapon to make a ranged attack.
 | Two-Handed | You require two hands to use this attack.
-| Versatile | You can use this damage if the attack is made with two hands.
+| Versatile | You can use this [Stress]() if the attack is made with two hands.
 
 ## Defence
 

--- a/pages/combat/bonus-actions.md
+++ b/pages/combat/bonus-actions.md
@@ -17,7 +17,7 @@ You can make the following **Bonus Actions** by default:
 
 Bonus Action
 
-If you're wielding a [Light](../../pages/combat/attacks.md#describing-attacks) melee weapon you can use your other hand to make an attack with another **Light** melee or thrown weapon. Don’t add your [Attribute](../pages/characters/attributes.md) to the damage, unless that modifier is negative.
+If you're wielding a [Light](../../pages/combat/attacks.md#describing-attacks) melee weapon you can use your other hand to make an attack with another **Light** melee or thrown weapon. Don’t add your [Attribute](../pages/characters/attributes.md) to the [Stress](), unless that modifier is negative.
 
 </section>
 

--- a/pages/combat/stamina.md
+++ b/pages/combat/stamina.md
@@ -4,13 +4,27 @@ Rule
 
 **Stamina** represent a combination of physical and mental durability, grit, willpower, and just plain luck:
 
- + When a creature takes damage, it is subtracted from its **Stamina**.
+ + When a creature takes **Stress**, it is subtracted from its **Stamina**.
  + When a creature drops to 0 **Stamina** it dies.
 
-## Damage
+## Stress
 
 Rule
 
-**Stamina** damage is abstract. It doesn't just represent physical harm. It can represent mental stress, off-balance, misfortune, or shock.
+**Stamina** damage is abstract. It doesn't just represent physical harm. It can represent mental stress, off-balance, misfortune or shock.
 
 A successful [Attack](../../pages/combat/attacks.md) might translate to a near miss that knocks you off-balance, a palpating fear you're outmatched, a light scratch, or temporary concussion. Or, of course, a direct hit.
+
+## Out of Action
+
+Rule
+
+When you lose all your **Stamina** you are **Out of Action** and are unable to participate in the ongoing situation.
+
+You can recover when you:
+
+ * Gain **Stamina**
+ * Are stabilised using the [Medicine Skill](../../pages/characters/skills.md#medicine)
+ * Take a [Rest](../../pages/rules/rests.md)
+
+When the fight is over/are out of danger, you must roll for an [Affliction](../../pages/combat/afflictions.md) to see what happened to you.


### PR DESCRIPTION
Added rules for lingering injuries. These afflictions are intended to be inspirational, not descriptive. A character might die from a fatal blow, or be struck down by a heart attack. You might be slowed because you have lost a foot or because you have some kind of paralysis.

Is ranking these afflictions in order of seriousness problematic?